### PR TITLE
Specify type definitions for tsc node12 imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   ],
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./index.d.ts"
+      "require": "./dist/index.js"
     },
     "./lite": {
+      "types": "./index.d.ts",
       "import": "./lite/index.mjs",
-      "require": "./lite/index.js",
-      "types": "./index.d.ts"
+      "require": "./lite/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./index.d.ts"
     },
     "./lite": {
       "import": "./lite/index.mjs",
-      "require": "./lite/index.js"
+      "require": "./lite/index.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
In `tsc` nightly a new module resolutions scheme is introduced called `node12` or `nodenext` which uses this `"exports"` field in package.json files. When this is present and being used then the old root `"types"` is not used. You have to specify the types in the specific exports (when the files are not adjacent).