### PR TITLE
fix: prevent comparisons beyond typed array bounds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ export function dequal(foo, bar) {
 		}
 
 		if (ArrayBuffer.isView(foo)) {
-			if ((len=foo.byteLength) === bar.byteLength) {
+			if ((len=foo.length) === bar.length) {
 				while (len-- && foo[len] === bar[len]);
 			}
 			return len === -1;


### PR DESCRIPTION
Reverse iteration over TypedArrays was starting at `foo.byteLength - 1`, not `foo.length - 1`. For TypedArrays with .BYTES_PER_ELEMENT greater than 1, that was resulting in up to 7*`foo.length` needless pairs of out-of-bounds array accesses and `undefined === undefined` comparisons.