### PR TITLE
chore(ci): bump actions & test on node lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nodejs: [8, 10, 12, 18, 20, 22, 24]
+        nodejs: [8, 10, 12, 18, 20, 22]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nodejs: [8, 10, 12, 18]
+        nodejs: [8, 10, 12, 18, lts/*]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.nodejs }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nodejs: [8, 10, 12, 18, lts/*]
+        nodejs: [8, 10, 12, 18, 20, 22, 24]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
https://e18e.dev/ is promoting `dequal` as an alternative to `deep-equal`, so running tests on LTS versions could help people trust the switch. 

-> https://github.com/es-tooling/module-replacements/blob/main/docs/modules/deep-equal.md