### PR TITLE
update benchmarking

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -20,9 +20,9 @@ console.time('fast-deep-equal');
 const fastdeep = require('fast-deep-equal');
 console.timeEnd('fast-deep-equal');
 
-console.time('lodash/isequal');
-const lodash = require('lodash/isequal');
-console.timeEnd('lodash/isequal');
+console.time('lodash/isEqual');
+const lodash = require('lodash/isEqual');
+console.timeEnd('lodash/isEqual');
 
 console.time('nano-equal');
 const nanoequal = require('nano-equal');

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,6 +1,6 @@
 const { join } = require('path');
 const { Suite } = require('benchmark');
-const klona = require('klona');
+const { klona } = require('klona');
 
 console.log('Load times:');
 
@@ -12,12 +12,16 @@ console.time('util');
 const { isDeepStrictEqual } = require('util');
 console.timeEnd('util');
 
+console.time('deep-equal');
+const deepEqual = require('deep-equal');
+console.timeEnd('deep-equal');
+
 console.time('fast-deep-equal');
 const fastdeep = require('fast-deep-equal');
 console.timeEnd('fast-deep-equal');
 
 console.time('lodash/isequal');
-const lodash = require('lodash/isequal');
+const lodash = require('lodash/isEqual');
 console.timeEnd('lodash/isequal');
 
 console.time('nano-equal');
@@ -86,6 +90,7 @@ function runner(name, contenders) {
 runner('basic', {
 	'assert.deepStrictEqual': naiive,
 	'util.isDeepStrictEqual': isDeepStrictEqual,
+	'deep-equal': deepEqual,
 	'fast-deep-equal': fastdeep,
 	'lodash.isEqual': lodash,
 	'nano-equal': nanoequal,
@@ -97,6 +102,7 @@ runner('basic', {
 runner('complex', {
 	'assert.deepStrictEqual': naiive,
 	'util.isDeepStrictEqual': isDeepStrictEqual,
+	'deep-equal': deepEqual,
 	'lodash.isEqual': lodash,
 	'dequal': dequal,
 });

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,6 +1,6 @@
 const { join } = require('path');
 const { Suite } = require('benchmark');
-const { klona } = require('klona');
+const klona = require('klona');
 
 console.log('Load times:');
 
@@ -21,7 +21,7 @@ const fastdeep = require('fast-deep-equal');
 console.timeEnd('fast-deep-equal');
 
 console.time('lodash/isequal');
-const lodash = require('lodash/isEqual');
+const lodash = require('lodash/isequal');
 console.timeEnd('lodash/isequal');
 
 console.time('nano-equal');

--- a/bench/package.json
+++ b/bench/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "benchmark": "2.1.4",
+    "deep-equal": "2.2.3",
     "dequal": "file:../",
     "fast-deep-equal": "3.1.3",
     "klona": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "node": ">=6"
   },
   "scripts": {
-    "bench": "node ./bench",
     "build": "bundt",
     "pretest": "npm run build",
     "postbuild": "echo \"lite\" | xargs -n1 cp -v index.d.ts",
@@ -51,15 +50,8 @@
     "equality"
   ],
   "devDependencies": {
-    "benchmark": "^2.1.4",
     "bundt": "1.0.2",
-    "deep-equal": "^2.2.3",
-    "dequal": "^2.0.3",
     "esm": "3.2.25",
-    "fast-deep-equal": "^3.1.3",
-    "klona": "^2.0.6",
-    "lodash": "^4.17.21",
-    "nano-equal": "^2.0.2",
     "uvu": "0.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node": ">=6"
   },
   "scripts": {
+    "bench": "node ./bench",
     "build": "bundt",
     "pretest": "npm run build",
     "postbuild": "echo \"lite\" | xargs -n1 cp -v index.d.ts",
@@ -50,8 +51,15 @@
     "equality"
   ],
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "bundt": "1.0.2",
+    "deep-equal": "^2.2.3",
+    "dequal": "^2.0.3",
     "esm": "3.2.25",
+    "fast-deep-equal": "^3.1.3",
+    "klona": "^2.0.6",
+    "lodash": "^4.17.21",
+    "nano-equal": "^2.0.2",
     "uvu": "0.3.2"
   }
 }


### PR DESCRIPTION
Having followed a `@testing-library/dom` dependency trail to this update:
https://github.com/A11yance/aria-query/pull/497

...it had me wondering how much of a performance improvement was gained between `deep-equal` to `dequal`. This PR just extends/updates current benchmarking to more easily get a conclusion on that... and wow! Looks pretty monumental unless I'm just simply doing something wrong. The load time of `deep-equal` alone is pretty far up there 😬

```sh
Load times:
assert: 0.334ms
util: 0.013ms
deep-equal: 72.528ms
fast-deep-equal: 0.925ms
lodash/isequal: 42.448ms
nano-equal: 0.801ms
dequal: 0.775ms
dequal/lite: 0.4ms

(basic) Validation: 
  ✔ assert.deepStrictEqual
  ✔ util.isDeepStrictEqual
  ✔ deep-equal
  ✔ fast-deep-equal
  ✔ lodash.isEqual
  ✔ nano-equal
  ✔ dequal/lite
  ✔ dequal

(basic) Benchmark: 
  assert.deepStrictEqual x 438,026 ops/sec ±6.23% (89 runs sampled)
  util.isDeepStrictEqual x 473,501 ops/sec ±2.66% (93 runs sampled)
  deep-equal             x 931 ops/sec ±0.70% (92 runs sampled)
  fast-deep-equal        x 1,872,682 ops/sec ±2.43% (91 runs sampled)
  lodash.isEqual         x 497,643 ops/sec ±0.66% (99 runs sampled)
  nano-equal             x 1,340,688 ops/sec ±0.72% (96 runs sampled)
  dequal/lite            x 2,169,654 ops/sec ±1.70% (95 runs sampled)
  dequal                 x 2,177,626 ops/sec ±0.41% (94 runs sampled)

(complex) Validation: 
  ✔ assert.deepStrictEqual
  ✔ util.isDeepStrictEqual
  ✔ deep-equal
  ✔ lodash.isEqual
  ✔ dequal

(complex) Benchmark: 
  assert.deepStrictEqual x 190,108 ops/sec ±1.19% (94 runs sampled)
  util.isDeepStrictEqual x 182,574 ops/sec ±7.89% (96 runs sampled)
  deep-equal             x 344 ops/sec ±1.37% (89 runs sampled)
  lodash.isEqual         x 94,137 ops/sec ±1.42% (94 runs sampled)
  dequal                 x 659,669 ops/sec ±0.80% (99 runs sampled)
```